### PR TITLE
Fix grammar on about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -39,7 +39,7 @@ export default function AboutPage() {
 
                     <Box>
                         <Text size="md" mb="sm">
-                            <strong>QuickTask</strong> a task manager. A quiet observer. A patient keeper of the things you said you’d do… but haven’t.
+                            <strong>QuickTask</strong> is a task manager. A quiet observer. A patient keeper of the things you said you’d do… but haven’t.
                         </Text>
 
                         <Text size="sm" color="dimmed" mb="xs">


### PR DESCRIPTION
## Summary
- fix grammatical typo in about page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f492b518883209eeac189bc5a4d4f