### PR TITLE
Fix README to match current stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
-
+QuickTask is a task manager built with Next.js and Mantine. Drag-and-drop tasks with dnd-kit.
 ## Getting Started
 
 First, run the development server:
@@ -18,7 +17,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- describe QuickTask and remove mention of next/font

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4936971c8320a52ac74d5bd98f33